### PR TITLE
Update README.m - disable spoof checking for sriov network attachment definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ metadata:
 spec:
   config: '{
   "type": "sriov",
-  "name": "sriov-network"
+  "name": "sriov-network",
+  "spoofchk":"off"
 }'
 ```
 
@@ -152,7 +153,8 @@ metadata:
 spec:
   config: '{
   "type": "sriov",
-  "name": "sriov-network"
+  "name": "sriov-network",
+  "spoofchk":"off"
 }'
 ```
 2) Deploy Network Attach Definition for Bond CNI:


### PR DESCRIPTION
The patch modifies the sriov network-attachment-definition
in the README file to disable spood checking. This is useful
for bondings, allowing mac change from within the container.