### PR TITLE
allow ipam plugin to be omitted from config and support bonding more than two interfaces

### DIFF
--- a/bond/bond.go
+++ b/bond/bond.go
@@ -265,6 +265,10 @@ func createBond(bondConf *bondingConfig, nspath string, ns ns.NetNS) (*current.I
 		return nil, fmt.Errorf("Failed to attached links to bond, error: %+v", err)
 	}
 
+	if err := netNsHandle.LinkSetUp(bondLinkObj); err != nil {
+		return nil, fmt.Errorf("Failed to set bond link UP, error: %v", err)
+	}
+
 	bond.Name = bondConf.Name
 
 	// Re-fetch interface to get all properties/attributes

--- a/bond/bond.go
+++ b/bond/bond.go
@@ -78,7 +78,7 @@ func getLinkObjectsFromConfig(bondConf *bondingConfig, netNsHandle *netlink.Hand
 		linkNames = append(linkNames, s)
 	}
 	linkObjectsToBond := []netlink.Link{}
-	if len(linkNames) > 1 && len(linkNames) <= 2 { // currently only supporting two links to one bond
+	if len(linkNames) >= 2 { // currently supporting two or more links to one bond
 		for _, linkName := range linkNames {
 			linkObject, err := checkLinkExists(linkName, netNsHandle)
 			if err != nil {
@@ -87,7 +87,7 @@ func getLinkObjectsFromConfig(bondConf *bondingConfig, netNsHandle *netlink.Hand
 			linkObjectsToBond = append(linkObjectsToBond, linkObject)
 		}
 	} else {
-		return nil, fmt.Errorf("Bonding requires exactly two links, we have %+v", len(linkNames))
+		return nil, fmt.Errorf("Bonding requires at least two links, we have %+v", len(linkNames))
 	}
 	return linkObjectsToBond, nil
 }
@@ -194,7 +194,7 @@ func setLinksinNetNs(bondConf *bondingConfig, nspath string, releaseLinks bool) 
 		}
 	}
 
-	if len(linkNames) > 1 && len(linkNames) <= 2 { // currently only supporting two links to one bond
+	if len(linkNames) >= 2 { // currently supporting two or more links to one bond
 		for _, linkName := range linkNames {
 			// get interface link in the network namespace
 			link, err := netlink.LinkByName(linkName)
@@ -219,7 +219,7 @@ func setLinksinNetNs(bondConf *bondingConfig, nspath string, releaseLinks bool) 
 
 		}
 	} else {
-		return fmt.Errorf("Bonding requires exactly two links, we have %+v", len(linkNames))
+		return fmt.Errorf("Bonding requires at least two links, we have %+v", len(linkNames))
 	}
 
 	return nil


### PR DESCRIPTION
Allow the ipam plugin execution to be skipped.

For my purposes the bond does not need an IP (i am creating a vlan of the bond and ip'ing that).

I also ran `gofmt`.